### PR TITLE
Add a sample designer to the business object sample

### DIFF
--- a/Using Business Objects in the Report/Controllers/DesignerController.cs
+++ b/Using Business Objects in the Report/Controllers/DesignerController.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Stimulsoft.Report;
+using Stimulsoft.Report.Mvc;
+using BusinessObjects;
+
+namespace Using_Business_Objects_in_the_Report.Controllers
+{
+    [Route(@"{controller}/{action}")]
+    public class DesignerController : Controller
+    {
+        static DesignerController()
+        {
+            // How to Activate
+            //Stimulsoft.Base.StiLicense.Key = "6vJhGtLLLz2GNviWmUTrhSqnO...";
+            //Stimulsoft.Base.StiLicense.LoadFromFile("license.key");
+            //Stimulsoft.Base.StiLicense.LoadFromStream(stream);
+        }
+
+        public IActionResult Index()
+        {
+            return View("Index");
+        }
+
+        public IActionResult PreviewReport()
+        {
+            StiReport report = StiNetCoreDesigner.GetActionReportObject(this);
+            report.RegBusinessObject("EmployeeIEnumerable", CreateBusinessObjectsIEnumerable.GetEmployees());
+            return StiNetCoreDesigner.PreviewReportResult(this, report);
+        }
+
+        public IActionResult GetReportIEnumerableBO()
+        {
+            var report = new StiReport();
+            report.Load(StiNetCoreHelper.MapPath(this, "Reports/BusinessObjects_IEnumerable_BO.mrt"));
+            report.RegBusinessObject("EmployeeIEnumerable", CreateBusinessObjectsIEnumerable.GetEmployees());
+            report.Dictionary.SynchronizeBusinessObjects(2);
+
+            return StiNetCoreDesigner.GetReportResult(this, report);
+        }
+
+        public IActionResult DesignerEvent()
+        {
+            return StiNetCoreDesigner.DesignerEventResult(this);
+        }
+    }
+}

--- a/Using Business Objects in the Report/Views/Designer/Index.cshtml
+++ b/Using Business Objects in the Report/Views/Designer/Index.cshtml
@@ -13,8 +13,6 @@
         {
             CacheMode = StiServerCacheMode.StringCache,
             Controller = "Designer",
-            //RouteTemplate = Model != null ? $"/Report/{Model.ID}" : "/Report"
-
         },
         Actions =
         {

--- a/Using Business Objects in the Report/Views/Designer/Index.cshtml
+++ b/Using Business Objects in the Report/Views/Designer/Index.cshtml
@@ -1,0 +1,25 @@
+﻿@using Stimulsoft.Report.Mvc;
+@using Stimulsoft.Report.Web
+
+@{
+    Layout = "_Layout";
+    ViewBag.Title = "some stuff [BusinessObject]";
+}
+
+@Html.StiNetCoreDesigner(new StiNetCoreDesignerOptions()
+    {
+        Theme = StiDesignerTheme.Office2022DarkGrayBlue,
+        Server =
+        {
+            CacheMode = StiServerCacheMode.StringCache,
+            Controller = "Designer",
+            //RouteTemplate = Model != null ? $"/Report/{Model.ID}" : "/Report"
+
+        },
+        Actions =
+        {
+            GetReport = "GetReportIEnumerableBO",
+            DesignerEvent = "DesignerEvent",
+            PreviewReport = "PreviewReport",
+        }
+    })

--- a/Using Business Objects in the Report/Views/Viewer/Index.cshtml
+++ b/Using Business Objects in the Report/Views/Viewer/Index.cshtml
@@ -14,3 +14,5 @@ BusinessObject:
 @Html.ActionLink("ITypedList", "ActionITypedListBO")
 <br />
 @Html.ActionLink("IEnumerable", "ActionIEnumerableBO")
+<br />
+@Html.ActionLink("Designer", "Index", "Designer")


### PR DESCRIPTION
I needed a clear and simple test of the report designer when using business objects. Since that sample was missing, I created it and I'm submitting it to the community